### PR TITLE
added a missing '6' to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Which means:
 </Grid>
 ```
 
-Therefore, in the above example, we have defined a Grid that will have `1 column` and `1 row` at __xs__, and then ` columns` and `5 rows` at __sm__.
+Therefore, in the above example, we have defined a Grid that will have `1 column` and `1 row` at __xs__, and then `6 columns` and `5 rows` at __sm__.
 
 Now let's add a Cell.
 


### PR DESCRIPTION
Just missing a `6` when describing Cell and Grid props in the readme

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
 - [x] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
